### PR TITLE
MAP-1459 8 ReportService Scenario getPrisonContentFor coroutines

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
   testImplementation("io.jsonwebtoken:jjwt-jackson:0.12.6")
   testImplementation("org.flywaydb:flyway-core")
 
+  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0-RC.2")
+
   runtimeOnly("org.postgresql:postgresql:42.7.3")
   testRuntimeOnly("org.flywaydb:flyway-database-postgresql")
   testRuntimeOnly("com.h2database:h2:2.3.232")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsuofdataapi/integration/service/ReportServiceCoroutinesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsuofdataapi/integration/service/ReportServiceCoroutinesTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.InjectMocks
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
+import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsuofdataapi.model.ReportDetail
 import uk.gov.justice.digital.hmpps.hmppsuofdataapi.repository.ReportRepository
 import uk.gov.justice.digital.hmpps.hmppsuofdataapi.repository.ReportSummaryRepository
@@ -74,7 +74,7 @@ class ReportServiceCoroutinesTest {
       },
     )
 
-    `when`(
+    whenever(
       reportRepository.findAllByOffenderNoAndIncidentDateBetween(
         offenderNumber,
         fromDate.atStartOfDay(),
@@ -82,8 +82,8 @@ class ReportServiceCoroutinesTest {
       ),
     ).thenReturn(listOf(report1, report2))
 
-    `when`(reportServiceMock.getReportsByOffenderNumberAndDateWindow(offenderNumber, fromDate, toDate)).thenReturn(listReportDetail)
-    `when`(reportServiceMock.getPrisonContentFor(offenderNumber, fromDate, toDate)).thenReturn(expectedHmppsSubjectAccessRequestContent)
+    whenever(reportServiceMock.getReportsByOffenderNumberAndDateWindow(offenderNumber, fromDate, toDate)).thenReturn(listReportDetail)
+    whenever(reportServiceMock.getPrisonContentFor(offenderNumber, fromDate, toDate)).thenReturn(expectedHmppsSubjectAccessRequestContent)
 
     val gotHmppsSubjectAccessRequestContent = reportService.getPrisonContentFor(offenderNumber, fromDate, toDate)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsuofdataapi/integration/service/ReportServiceCoroutinesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsuofdataapi/integration/service/ReportServiceCoroutinesTest.kt
@@ -1,0 +1,92 @@
+package uk.gov.justice.digital.hmpps.hmppsuofdataapi.integration.service
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.InjectMocks
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import uk.gov.justice.digital.hmpps.hmppsuofdataapi.model.ReportDetail
+import uk.gov.justice.digital.hmpps.hmppsuofdataapi.repository.ReportRepository
+import uk.gov.justice.digital.hmpps.hmppsuofdataapi.repository.ReportSummaryRepository
+import uk.gov.justice.digital.hmpps.hmppsuofdataapi.service.ReportService
+import uk.gov.justice.hmpps.kotlin.sar.HmppsSubjectAccessRequestContent
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class ReportServiceCoroutinesTest {
+
+  private lateinit var reportRepository: ReportRepository
+  private lateinit var reportSummaryRepository: ReportSummaryRepository
+  private lateinit var reportServiceMock: ReportService
+
+  @InjectMocks
+  private lateinit var reportService: ReportService
+
+  @BeforeEach
+  fun setUp() {
+    reportRepository = mock(ReportRepository::class.java)
+    reportSummaryRepository = mock(ReportSummaryRepository::class.java)
+
+    reportService = ReportService(reportRepository, reportSummaryRepository)
+    reportServiceMock = mock(ReportService::class.java)
+  }
+
+  val offenderNumber = "G1234A"
+  val offenderNumberB = "G1234AB"
+
+  val report1 = buildReport(1, offenderNumber)
+  val report2 = buildReport(2, offenderNumberB)
+  val fromDate = LocalDate.of(2024, 9, 1)
+  val toDate = LocalDate.of(2024, 9, 30)
+
+  private fun buildReport(
+    id: Long,
+    offenderNumber: String,
+  ): ReportDetail {
+    return ReportDetail(
+      id, "{}",
+      "user_id",
+      1,
+      1234,
+      LocalDateTime.now(),
+      "IN_PROGRESS",
+      null,
+      offenderNumber,
+      "reporter_name",
+      LocalDateTime.of(2024, 1, 1, 14, 0),
+      "MDI",
+      LocalDateTime.now(),
+      null,
+    )
+  }
+
+  @Test
+  fun `test getPrisonContentFor returns correct reports coroutines runTest`() = runTest {
+    val listReportDetail = listOf(report1, report2)
+
+    val expectedHmppsSubjectAccessRequestContent = HmppsSubjectAccessRequestContent(
+      content = listOf(report1, report2).map {
+        it.toDto(
+          includeStatements = true,
+          includeFormResponse = true,
+        )
+      },
+    )
+
+    `when`(
+      reportRepository.findAllByOffenderNoAndIncidentDateBetween(
+        offenderNumber,
+        fromDate.atStartOfDay(),
+        toDate.atStartOfDay(),
+      ),
+    ).thenReturn(listOf(report1, report2))
+
+    `when`(reportServiceMock.getReportsByOffenderNumberAndDateWindow(offenderNumber, fromDate, toDate)).thenReturn(listReportDetail)
+    `when`(reportServiceMock.getPrisonContentFor(offenderNumber, fromDate, toDate)).thenReturn(expectedHmppsSubjectAccessRequestContent)
+
+    val gotHmppsSubjectAccessRequestContent = reportService.getPrisonContentFor(offenderNumber, fromDate, toDate)
+
+    assertEquals(gotHmppsSubjectAccessRequestContent, expectedHmppsSubjectAccessRequestContent)
+  }
+}


### PR DESCRIPTION
This test tackles  scenario where we need to test suspended fun, it covers partially some red lines. It gives room to increase coverage for some branches (yellow lines) and so on

before
![image](https://github.com/user-attachments/assets/0b8eba13-6a43-47fc-bac4-d09b382e1465)

after
![image](https://github.com/user-attachments/assets/22fb006d-c6d9-45ff-a049-62f619eb3bee)

