### PR TITLE
MAP-1459 8 ReportService Scenario getReportsForSubjectAccess when only  startDate , when only toDate , when without both and empty

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsuofdataapi/integration/service/ReportServiceCoroutinesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsuofdataapi/integration/service/ReportServiceCoroutinesTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsuofdataapi.integration.service
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -106,6 +105,7 @@ class ReportServiceCoroutinesTest {
 
     val reports = reportService.getReportsForSubjectAccess(offenderNumber, fromDate, null)
     assertEquals(listReportDetail, gotListReportDetail)
+    assertEquals(listReportDetail, reports)
     assert(reports.size == 1)
   }
 
@@ -133,7 +133,6 @@ class ReportServiceCoroutinesTest {
       listReportDetail,
     )
     val gotHmppsSubjectAccessRequestContent = reportService.getPrisonContentFor(offenderNumber, null, toDate)
-    assertNotNull(listReportDetail)
     assertEquals(expectedHmppsSubjectAccessRequestContent, gotHmppsSubjectAccessRequestContent)
   }
 
@@ -158,7 +157,6 @@ class ReportServiceCoroutinesTest {
 
     whenever(reportServiceMock.getReportDetailByOffenderNumber(offenderNumber)).thenReturn(listReportDetail)
     val gotHmppsSubjectAccessRequestContent = reportService.getPrisonContentFor(offenderNumber, null, null)
-    assertNotNull(listReportDetail)
     assertEquals(expectedHmppsSubjectAccessRequestContent, gotHmppsSubjectAccessRequestContent)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsuofdataapi/integration/service/ReportServiceCoroutinesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsuofdataapi/integration/service/ReportServiceCoroutinesTest.kt
@@ -37,8 +37,8 @@ class ReportServiceCoroutinesTest {
 
   val report1 = buildReport(1, offenderNumber)
   val report2 = buildReport(2, offenderNumberB)
-  val fromDate = LocalDate.of(2024, 9, 1)
-  val toDate = LocalDate.of(2024, 9, 30)
+  var fromDate = LocalDate.of(2024, 1, 1)
+  var toDate = LocalDate.of(2024, 1, 9)
 
   private fun buildReport(
     id: Long,
@@ -49,14 +49,14 @@ class ReportServiceCoroutinesTest {
       "user_id",
       1,
       1234,
-      LocalDateTime.now(),
+      LocalDateTime.of(2024, 1, 10, 14, 0),
       "IN_PROGRESS",
       null,
       offenderNumber,
       "reporter_name",
-      LocalDateTime.of(2024, 1, 1, 14, 0),
+      LocalDateTime.of(2024, 1, 10, 14, 0),
       "MDI",
-      LocalDateTime.now(),
+      LocalDateTime.of(2024, 1, 10, 14, 0),
       null,
     )
   }
@@ -88,5 +88,22 @@ class ReportServiceCoroutinesTest {
     val gotHmppsSubjectAccessRequestContent = reportService.getPrisonContentFor(offenderNumber, fromDate, toDate)
 
     assertEquals(gotHmppsSubjectAccessRequestContent, expectedHmppsSubjectAccessRequestContent)
+  }
+
+  @Test
+  fun `test getReportsForSubjectAccess returns correct reports coroutines runTest with only fromDate `() = runTest {
+    val gotListReportDetail = listOf(report1)
+    val listReportDetail = listOf(report1)
+
+    whenever(
+      reportRepository.findAllByOffenderNoAndIncidentDateAfter(
+        offenderNumber,
+        fromDate.atStartOfDay(),
+      ),
+    ).thenReturn(gotListReportDetail)
+
+    val reports = reportService.getReportsForSubjectAccess(offenderNumber, fromDate, null)
+    assertEquals(listReportDetail, gotListReportDetail)
+    assert(reports.size == 1)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsuofdataapi/integration/service/ReportServiceCoroutinesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsuofdataapi/integration/service/ReportServiceCoroutinesTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsuofdataapi.integration.service
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.InjectMocks
@@ -159,5 +160,26 @@ class ReportServiceCoroutinesTest {
     val gotHmppsSubjectAccessRequestContent = reportService.getPrisonContentFor(offenderNumber, null, null)
     assertNotNull(listReportDetail)
     assertEquals(expectedHmppsSubjectAccessRequestContent, gotHmppsSubjectAccessRequestContent)
+  }
+
+  @Test
+  fun `test getReportsForSubjectAccess returns null when reports are empty `() = runTest {
+    var listReportDetailVoid: List<ReportDetail> = emptyList()
+
+    whenever(
+      reportRepository.findAllByOffenderNoAndIncidentDateBetween(
+        offenderNumber,
+        fromDate.atStartOfDay(),
+        toDate.atStartOfDay(),
+      ),
+    ).thenReturn(listReportDetailVoid)
+
+    whenever(reportServiceMock.getReportsByOffenderNumberAndDateWindow(offenderNumber, fromDate, toDate)).thenReturn(
+      listReportDetailVoid,
+    )
+
+    val gotHmppsSubjectAccessRequestContent = reportService.getPrisonContentFor(offenderNumber, fromDate, toDate)
+    assert(listReportDetailVoid.isEmpty())
+    assertNull(gotHmppsSubjectAccessRequestContent)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsuofdataapi/integration/service/ReportServiceCoroutinesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsuofdataapi/integration/service/ReportServiceCoroutinesTest.kt
@@ -104,7 +104,7 @@ class ReportServiceCoroutinesTest {
     ).thenReturn(gotListReportDetail)
 
     val reports = reportService.getReportsForSubjectAccess(offenderNumber, fromDate, null)
-    assertEquals(listReportDetail, gotListReportDetail)
+
     assertEquals(listReportDetail, reports)
     assert(reports.size == 1)
   }


### PR DESCRIPTION
Just fewer scenarios for this suspended fun where there are startDate and toDate or any of them are null or both.

before
![image](https://github.com/user-attachments/assets/cf6930ee-5510-45aa-8562-659c197f36ae)


after
![image](https://github.com/user-attachments/assets/bc495dc6-631b-428a-a3e7-b117b57e6221)