### PR TITLE
MAP-1818 merging with hmpps-kotlin-template  and update project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@8
+  hmpps: ministryofjustice/hmpps@10
 
 parameters:
   alerts-slack-channel:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2021 Crown Copyright (Ministry of Justice)
+Copyright (c) 2020-2024 Crown Copyright (Ministry of Justice)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@
 
 This service exists to expose Use of Force data in a read-only manner.
 Any data input/modification is done via the [Use of Force](https://github.com/ministryofjustice/use-of-force) service.
+
+#### How to sync the project with HMPPS-template-kotlin
+Find out missing commits https://github.com/ministryofjustice/hmpps-template-kotlin/commits/main/ following `sync commit` above.
+Cherry Pick the changes by calling `git cherry-pick <<commit_id>>..<<commit_id>>` if you want to Cherry pick only one commit call `git cherry-pick <<commit_id>>`

--- a/applicationinsights.dev.json
+++ b/applicationinsights.dev.json
@@ -14,22 +14,19 @@
     "destination": "console"
   },
   "sampling": {
-    "percentage": 100
-  },
-  "preview": {
-    "sampling": {
-      "overrides": [
-        {
-          "attributes": [
-            {
-              "key": "http.url",
-              "value": "https?://[^/]+/health.*",
-              "matchType": "regexp"
-            }
-          ],
-          "percentage": 100
-        }
-      ]
-    }
+    "percentage": 100,
+    "overrides": [
+      {
+        "telemetryType": "request",
+        "attributes": [
+          {
+            "key": "http.url",
+            "value": "https?://[^/]+/health.*",
+            "matchType": "regexp"
+          }
+        ],
+        "percentage": 100
+      }
+    ]
   }
 }

--- a/applicationinsights.json
+++ b/applicationinsights.json
@@ -14,22 +14,19 @@
     "destination": "console"
   },
   "sampling": {
-    "percentage": 100
-  },
-  "preview": {
-    "sampling": {
-      "overrides": [
-        {
-          "attributes": [
-            {
-              "key": "http.url",
-              "value": "https?://[^/]+/health.*",
-              "matchType": "regexp"
-            }
-          ],
-          "percentage": 10
-        }
-      ]
-    }
+    "percentage": 100,
+    "overrides": [
+      {
+        "telemetryType": "request",
+        "attributes": [
+          {
+            "key": "http.url",
+            "value": "https?://[^/]+/health.*",
+            "matchType": "regexp"
+          }
+        ],
+        "percentage": 10
+      }
+    ]
   }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 
 ##############################################################################
 #

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -13,6 +13,8 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 @rem
+@rem SPDX-License-Identifier: Apache-2.0
+@rem
 
 @if "%DEBUG%"=="" @echo off
 @rem ##########################################################################

--- a/helm_deploy/hmpps-uof-data-api/Chart.yaml
+++ b/helm_deploy/hmpps-uof-data-api/Chart.yaml
@@ -5,8 +5,8 @@ name: hmpps-uof-data-api
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: "2.9"
+    version: "3.6"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: "1.3"
+    version: "1.10"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
It is required to align the updates with the hmpps-kotlin-template.

+ There is a orbs updated @10, gradle and helm chart.yml versions updates.
+ migrate circle ci to github actions have been already worked.
+ applicationinsights.json and applicationinsights-dev.json have been updated accordingly.
