### PR TITLE
MAP-1984 use alternative slack channel

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,4 +14,4 @@ generic-service:
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
-  alertSeverity: move-a-prisoner-dev-private
+  alertSeverity: digital-prison-service-dev


### PR DESCRIPTION
Change requested to change slack channel that preprod alerts go to